### PR TITLE
Fix: fixed app not working on Splunk Cloud

### DIFF
--- a/package/bin/SecKit_SA_geolocation_rh_updater.py
+++ b/package/bin/SecKit_SA_geolocation_rh_updater.py
@@ -121,7 +121,7 @@ class GeoipUpdateHandler(rest_handler.RESTHandler):
                         shell=True,
                         stderr=subprocess.STDOUT,
                     )  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use
-                except CalledProcessError as e:
+                except subprocess.CalledProcessError as e:
                     logger.exception(e)
                     logger.error("command args:\n")
                     logger.error(e.cmd)

--- a/package/bin/SecKit_SA_geolocation_rh_updater.py
+++ b/package/bin/SecKit_SA_geolocation_rh_updater.py
@@ -115,16 +115,22 @@ class GeoipUpdateHandler(rest_handler.RESTHandler):
                         "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/data/"
                     ),
                     "-f",
-                    file.name
+                    file.name,
                 ]
 
                 try:
-                    subprocess.check_output(['chmod', '+x', os.path.expandvars(
-                        "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/bin/geoipupdate/linux_amd64/geoipupdate"
-                    )])
+                    subprocess.check_output(
+                        [
+                            'chmod', 
+                            '+x', 
+                            os.path.expandvars(
+                                "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/bin/geoipupdate/linux_amd64/geoipupdate"
+                            ),
+                        ]
+                    )
                     subprocess.check_output(
                         args,
-                        shell= False,
+                        shell=False,
                         stderr=subprocess.STDOUT,
                     )  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use
                 except subprocess.CalledProcessError as e:

--- a/package/bin/SecKit_SA_geolocation_rh_updater.py
+++ b/package/bin/SecKit_SA_geolocation_rh_updater.py
@@ -121,8 +121,8 @@ class GeoipUpdateHandler(rest_handler.RESTHandler):
                 try:
                     subprocess.check_output(
                         [
-                            'chmod', 
-                            '+x', 
+                            'chmod',
+                            '+x',
                             os.path.expandvars(
                                 "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/bin/geoipupdate/linux_amd64/geoipupdate"
                             ),

--- a/package/bin/SecKit_SA_geolocation_rh_updater.py
+++ b/package/bin/SecKit_SA_geolocation_rh_updater.py
@@ -121,8 +121,8 @@ class GeoipUpdateHandler(rest_handler.RESTHandler):
                 try:
                     subprocess.check_output(
                         [
-                            'chmod',
-                            '+x',
+                            "chmod",
+                            "+x",
                             os.path.expandvars(
                                 "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/bin/geoipupdate/linux_amd64/geoipupdate"
                             ),

--- a/package/bin/SecKit_SA_geolocation_rh_updater.py
+++ b/package/bin/SecKit_SA_geolocation_rh_updater.py
@@ -105,20 +105,26 @@ class GeoipUpdateHandler(rest_handler.RESTHandler):
                         )
 
                 file.flush()
-                guargs = str(
+                args = [
                     os.path.expandvars(
-                        "-v -d $SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/data/ -f "
-                        + file.name
-                    )
-                )
+                        "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/bin/geoipupdate/linux_amd64/geoipupdate"
+                    ),
+                    "-v",
+                    "-d",
+                    os.path.expandvars(
+                        "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/data/"
+                    ),
+                    "-f",
+                    file.name
+                ]
 
                 try:
+                    subprocess.check_output(['chmod', '+x', os.path.expandvars(
+                        "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/bin/geoipupdate/linux_amd64/geoipupdate"
+                    )])
                     subprocess.check_output(
-                        [
-                            "$SPLUNK_HOME/etc/apps/SecKit_SA_geolocation/bin/geoipupdate/linux_amd64/geoipupdate "
-                            + guargs
-                        ],
-                        shell=True,
+                        args,
+                        shell= False,
                         stderr=subprocess.STDOUT,
                     )  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use
                 except subprocess.CalledProcessError as e:

--- a/package/metadata/default.meta
+++ b/package/metadata/default.meta
@@ -1,8 +1,8 @@
 
 []
-access = read : [ * ], write : [ admin ]
+access = read : [ * ], write : [ admin, sc_admin ]
 export = system
 
 [views]
-access = read : [ * ], write : [ admin ]
+access = read : [ * ], write : [ admin, sc_admin ]
 export = none


### PR DESCRIPTION
Added a code that changes `geoipupdate` file permissions which was the root cause of the exception being raised when the app was running on Cloud. Also added a `subprocess` module to CalledProcessError lack of which prevented the app from explicitly showing what was it caused by.